### PR TITLE
Enhancement: Save CSVs in CWD

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,8 +65,7 @@ To get CSVs for all states, enter:
     getpop all
 
 
-CSVs will be saved in a new directory called 'data' in the current working directory. See 'advanced usage' to override
-the location where CSVs are saved.
+CSVs will be saved in the current working directory. See 'advanced usage' to specify a different location to save CSVs.
 
 Programmatic
 ================
@@ -88,7 +87,7 @@ Command line
 ================
 
 Getpop takes one or more two-letter state abbreviations as positional arguments in order to determine which state
-CSVs will be generated. Getpop's CLI also takes a handful of optional arguments that modify its actions.
+CSVs will be generated. Getpop's CLI also takes certain optional arguments that modify its actions.
 
 
 ``--save-dir, --dir``
@@ -97,14 +96,9 @@ TEXT. Path of directory where CSV files will be saved. Defaults to saving them i
 working directory. If the directory you specify doesn't exist, getpop will create it.
 
 
-``--clear-dir, --cdir``
-
-Deletes all existing files in save_dir path. Defaults to false.
-
-
 ``--help``
 
-Show this message and exit.
+Returns a list of getpop's CLI options.
 
 
 Here's an example that stores the CSVs in a directory in your current working directory called
@@ -112,7 +106,7 @@ Here's an example that stores the CSVs in a directory in your current working di
 
 ::
 
-    getpop ny ca tx --save-dir ./your_custom_directory --clear-dir
+    getpop ny ca tx --save-dir ./your_custom_directory
 
 License
 -----------

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+1.94.7 (2020–07–13)
+------------------------------
+
+* Save CSVs in current working directory rather than 'data' directory in CWD.
+* Remove --clear-dir flag to prevent user from accidentally deleting files and folders.
+* Minor refactoring of parsing/saving process.
+
 1.94.6 (2020–07–13)
 ------------------------------
 

--- a/get_pop/__init__.py
+++ b/get_pop/__init__.py
@@ -2,4 +2,4 @@
 
 __project__ = "get_pop"
 __author__ = """DSR"""
-__version__ = "1.94.6"
+__version__ = "1.94.7"

--- a/get_pop/cli.py
+++ b/get_pop/cli.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import click
 from typing import Union
-from get_pop.definitions import DIR_DATA
+from get_pop.definitions import CWD
 from get_pop.get_pop import get_pop
 from get_pop.static.constants import state_index
 
@@ -13,17 +13,11 @@ clean_states = [x["abbrv"] for x in state_index] + ["all"]
 @click.option(
     "--save-dir",
     "--dir",
-    default=DIR_DATA,
-    help="Absolute path of directory where CSV files will be output. Defaults to saving them in /data in the current "
+    default=CWD,
+    help="Path of directory where CSV files will be output. Defaults to saving in the current "
     "working directory",
 )
-@click.option(
-    "--clear-dir",
-    "--cdir",
-    is_flag=True,
-    help="Deletes all existing files in save_dir path. Defaults to false.",
-)
-def main(states: tuple, save_dir: Union[str, Path], clear_dir: bool) -> None:
+def main(states: tuple, save_dir: Union[str, Path]) -> None:
     """
     CLI API using click library. Generates CSVs of county-level state data based on
     provided arguments.
@@ -32,11 +26,10 @@ def main(states: tuple, save_dir: Union[str, Path], clear_dir: bool) -> None:
         states (tuple): Tuple of one or more two-letter state abbreviations. Click takes a user's input
             from the command line and stores it as a tuple.
         save_dir (Union[str, Path]): (Optional) Path to directory where CSVs will be saved. Defaults to saving them in
-            /data in the current working directory
-        clear_dir (bool): (Optional) Deletes all existing files in save_dir path. Defaults to false
+            the current working directory
 
     Returns:
         None
     """
     states_list = list(states)  # convert from tuple to list
-    get_pop(states_list, save_dir=save_dir, clear_dir=clear_dir)
+    get_pop(states_list, save_dir=save_dir)

--- a/get_pop/definitions.py
+++ b/get_pop/definitions.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 from typing import List, Dict, Union, Callable
 from mypy_extensions import TypedDict
+import pandas as pd
 
 # This sets our root directory as the project directory
 PACKAGE_DIR = Path(
@@ -16,7 +17,6 @@ CWD = Path(os.getcwd())
 DIR_LOGS = PACKAGE_DIR / "logs"  # main dir for log-related files
 DIR_LOGS_OUTPUT = DIR_LOGS / "output"
 DIR_LOGS_CONFIG = DIR_LOGS / "config"
-DIR_DATA = CWD / "data"
 DIR_STATIC = PACKAGE_DIR / "static"
 
 # PATHS
@@ -28,4 +28,7 @@ PATH_USA_POP = DIR_STATIC / "usa_pop_counties_2019.csv"
 selected_values_type = List[TypedDict("state_dict", {"name": str, "abbrv": str})]
 selected_fields_type = List[
     TypedDict("field_dict", {"input_name": str, "output_name": str})
+]
+parsed_data_type = List[
+    TypedDict("parsed_data_dict", {"name": str, "data": pd.DataFrame})
 ]

--- a/get_pop/get_pop.py
+++ b/get_pop/get_pop.py
@@ -22,7 +22,6 @@ def get_pop(
     states: List[str],
     *,
     save_dir: Union[Path, str] = CWD,
-    clear_dir: bool = False,
     selected_fields: selected_fields_type = default_fields,
 ) -> None:
     """

--- a/get_pop/get_pop.py
+++ b/get_pop/get_pop.py
@@ -2,17 +2,18 @@ import logging
 from typing import List, Union
 
 from get_pop.modules.helper.misc import check_and_clear_dir
+from get_pop.modules.save.save_csv import save_csv
 from get_pop.static.constants import (
     state_index,
     value_field,
     field_cleaners,
     default_fields,
 )
-import pathlib
-from get_pop.definitions import selected_fields_type
-from get_pop.definitions import DIR_DATA
+from pathlib import Path
+from get_pop.definitions import selected_fields_type, CWD
 from get_pop.modules.init.init_program import init_program
 from get_pop.modules.parse.parse import parse_states
+from . import __project__
 
 clean_states = [x["abbrv"] for x in state_index]
 
@@ -20,7 +21,7 @@ clean_states = [x["abbrv"] for x in state_index]
 def get_pop(
     states: List[str],
     *,
-    save_dir: Union[pathlib.Path, str] = DIR_DATA,
+    save_dir: Union[Path, str] = CWD,
     clear_dir: bool = False,
     selected_fields: selected_fields_type = default_fields,
 ) -> None:
@@ -29,9 +30,8 @@ def get_pop(
 
     Args:
         states List[str]: List of states.
-        save_dir Union[pathlib.Path, str]: (Optional) Absolute path where CSV data will be stored. Defaults to /data
-            in current working directory.
-        clear_dir (bool):
+        save_dir Union[Path, str]: (Optional) Path where CSV data will be stored. Defaults to current
+            working directory.
         selected_fields (selected_fields_type): (Optional) A list of dictionaries with fields that should be
             included in the final CSV for each state. Default fields: "fips", "name", "population"
 
@@ -40,8 +40,7 @@ def get_pop(
     """
 
     # init
-    package_name = "getpop"
-    init_program(package_name)
+    init_program(__project__)
 
     # process states
     logging.info(f"Selected states: {states}")
@@ -55,18 +54,14 @@ def get_pop(
             ][0]
             selected_states.append(index_item)
 
-    # clear directory flag
-    if clear_dir:
-        check_and_clear_dir(save_dir)
-
-    parse_states(
+    parsed_data = parse_states(
         value_field=value_field,
         selected_values=selected_states,
         selected_fields=selected_fields,
         field_cleaners=field_cleaners,
-        file_partial="county",
-        save_dir=save_dir,
     )
 
+    save_csv(parsed_data, save_dir=save_dir, file_partial="county")
+
     # end
-    logging.info(f"{package_name} complete")
+    logging.info(f"{__project__} complete")

--- a/get_pop/modules/helper/misc.py
+++ b/get_pop/modules/helper/misc.py
@@ -15,14 +15,22 @@ def check_and_clear_dir(dir_path: Union[str, Path]) -> None:
     Returns:
         None
     """
-    # create or clean download dir
+    # ensures that dir_path is Path instance
     if isinstance(dir_path, str):
         dir_path = Path(dir_path)
-    if dir_path.is_dir():
-        # delete files from previous run
-        delete_dir_contents(dir_path)
-    else:
-        logging.info(f"Path {dir_path} is not a directory and can't be cleared")
+
+    if not dir_path.is_dir():
+        logging.warning(f"Path {dir_path} is not a directory and can't be cleared")
+        return
+
+    dir_contents = dir_path.glob("**/*")
+    dir_contents = [x for x in dir_contents]
+    if len(dir_contents) == 0:
+        logging.info(f"Path {dir_path} is empty. Nothing to clear")
+        return
+
+    delete_dir_contents(dir_path)
+    logging.info("Files deleted")
 
 
 def delete_dir_contents(dir_path: Union[str, Path]) -> None:

--- a/get_pop/modules/init/init_program.py
+++ b/get_pop/modules/init/init_program.py
@@ -1,8 +1,6 @@
 import logging
 from dotenv import load_dotenv
-from get_pop.definitions import DIR_DATA
 from get_pop.logs.config.logging import logs_config
-from get_pop.modules.helper.misc import delete_dir_contents
 from get_pop.modules.helper.time import utc_now
 from get_pop.modules.init.pandas_opts import pandas_opts
 from datetime import datetime
@@ -24,7 +22,6 @@ def init_program(package_name: str = None) -> datetime:
 
     # init logging
     program_start_time = utc_now()
-    timezone = program_start_time.tzinfo
     logs_config()
     if package_name:
         logging.info(f"Initializing {package_name}")

--- a/get_pop/modules/save/save_csv.py
+++ b/get_pop/modules/save/save_csv.py
@@ -1,0 +1,31 @@
+import logging
+from get_pop.definitions import parsed_data_type
+from pathlib import Path
+from typing import Union
+
+
+def save_csv(
+    parsed_data: parsed_data_type, save_dir: Union[Path, str], *, file_partial: str
+) -> None:
+    """
+    Saves a list of dictionaries containing pd.Dataframes as individual CSVs
+
+    Args:
+        parsed_data (parsed_data_type): List of dicts with data to save.
+        save_dir: Union[pathlib.Path, str]: Path where processed state CSVs will be saved
+        file_partial (str): (Optional) String that is used to determine part of final CSV filename for each state.
+
+    Returns:
+        None. CSVs are saved.
+    """
+    logging.info(f"CSVs will be saved in: {save_dir}")
+    for item in parsed_data:
+        name = item["name"]
+        data = item["data"]
+        filename = (
+            f"{name}-{file_partial}-pop.csv" if file_partial else f"{name}-pop.csv"
+        )
+        save_dir = Path(save_dir) if isinstance(save_dir, str) else save_dir
+        save_dir.mkdir(exist_ok=True)
+        output_path = save_dir / filename
+        data.to_csv(output_path, index=False)


### PR DESCRIPTION
* Save CSVs in current working directory by default rather than 'data' directory in CWD.
* Remove --clear-dir flag to prevent user from accidentally deleting files and folders.
* Minor refactoring of parsing/saving process.